### PR TITLE
コンテンツコメントがゲストで登録でき、承認ありにしているにもかかわらず、公開されてしまう(ルームは承認なし、ブロックで承認ありの設定の場合)

### DIFF
--- a/Locale/eng/LC_MESSAGES/content_comments.po
+++ b/Locale/eng/LC_MESSAGES/content_comments.po
@@ -79,3 +79,5 @@ msgstr "%s comments"
 msgid "Approving"
 msgstr "Approving"
 
+msgid "Guest(Not logged in)"
+msgid ""

--- a/Locale/jpn/LC_MESSAGES/content_comments.po
+++ b/Locale/jpn/LC_MESSAGES/content_comments.po
@@ -79,3 +79,5 @@ msgstr "%s コメント"
 msgid "Approving"
 msgstr "未承認"
 
+msgid "Guest(Not logged in)"
+msgstr "ゲスト(未ログイン)"

--- a/View/Elements/add.ctp
+++ b/View/Elements/add.ctp
@@ -33,10 +33,11 @@ $this->NetCommonsHtml->css(array('/content_comments/css/style.css'));
 			<?php echo $this->NetCommonsForm->hidden('_tmp.is_visitor_creatable', array('value' => $isVisitorCreatable)); ?>
 			<?php
 			// コメント承認機能 0:使わない=>公開 1:使う=>未承認
-			$status = $useCommentApproval ? WorkflowComponent::STATUS_APPROVAL_WAITING : WorkflowComponent::STATUS_PUBLISHED;
 			if (Current::permission('content_comment_publishable')) {
 				// 公開
-				$status = WorkflowComponent::STATUS_PUBLISHED;
+				$status = Current::permission('content_comment_publishable');
+			} else {
+				$status = WorkflowComponent::STATUS_APPROVAL_WAITING;
 			}
 			echo $this->NetCommonsForm->hidden('ContentComment.status', array('value' => $status));
 			?>

--- a/View/Elements/indexOnce.ctp
+++ b/View/Elements/indexOnce.ctp
@@ -21,7 +21,11 @@ $this->NetCommonsHtml->css(array('/content_comments/css/style.css'));
 ?>
 <div class="row">
 	<div class="col-xs-6">
-		<?php echo $this->DisplayUser->handleLink($contentComment, ['avatar' => true]); ?>
+		<?php if ($contentComment['ContentComment']['created_user']) : ?>
+			<?php echo $this->DisplayUser->handleLink($contentComment, ['avatar' => true]); ?>
+		<?php else : ?>
+			<?php echo __d('content_comments', 'Guest(Not logged in)'); ?>
+		<?php endif; ?>
 
 		<?php /* ステータス */ ?>
 		<?php echo $this->Workflow->label($contentComment['ContentComment']['status'], array(


### PR DESCRIPTION
未ログインの場合、「ゲスト(未ログイン)」のラベルを表示するように修正
https://github.com/NetCommons3/NetCommons3/issues/821